### PR TITLE
Update slack usage and add killswitch for emoji messages #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ Add the following to a message and the bot should get some info about that categ
 ### Elsewhere on Slack
 
 If @queryBot is in the channel (`/invite @querybot`) you can react to a users message with `:chat-gpt:` and the bot will respond to their message. You won't be able to do follow up messages etc. However, if the message you're reacting to has one of the !commands used in the unrestricted channel then these will be executed. Please be mindful of this (especially when using `!url`)
+
+The bot will react with :+1: and :-1: to every message it sends using this method. This makes the feature below easier to use.
+
+Sometimes the bot gets an answer wrong and you may not have permissions on Slack to delete an incorrect message. If you react with a :-1: the bot will replace it's answer with a removal message. If you react with a :+1: it will remove it's own approval emoji from the message to reduce the likelyhood that other users will misclick.

--- a/rsc/slack.manifest.json
+++ b/rsc/slack.manifest.json
@@ -18,7 +18,8 @@
                 "groups:history",
                 "reactions:read",
                 "users:read",
-                "groups:read"
+                "groups:read",
+                "reactions:write"
             ]
         }
     },


### PR DESCRIPTION
* Shift checking for authed user etc to matcher/middle functions
* Use event instead of body where possible
* Use dict.get where possible
* Add new killswitch feature that reacts to thumbs up/down emoji from authed users
* Add new required scope reactions:write