### PR TITLE
Support for restricted commands in react responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Create an account and generate an API token.
      * `debug [true|false]` - Outputs debugging data
      * `slack_error_webhook` - Sends logging data to a slack webhook
      * `name` - The name of the bot, not used currently.
+     * `restricted_commands` - Commands that should only be triggered by @bot tags. (and thus only in `unrestricted_channels`)
 * Run `auth_google.py` to authenticate with google for upcoming events
 * `./rsc/prompts.txt.example` -> `prompts.txt`
   * Add lines that should always be added to the bot. The first line is the system prompt and tells the bot what it is and what it's broadly expected to do. OpenAI has a [decent page](https://platform.openai.com/docs/guides/chat/instructing-chat-models) on system prompts.

--- a/rsc/config.json.example
+++ b/rsc/config.json.example
@@ -9,4 +9,5 @@
  "bot":{"dev":false,
         "debug":false,
         "slack_error_webhook":"",
-        "name":"queryBot"}}
+        "name":"queryBot",
+        "restricted_commands":["tidyhq"]}}

--- a/slack.py
+++ b/slack.py
@@ -45,6 +45,14 @@ def structure_reply(bot_id,messages,ignore_mention=False):
             conversation.append({"role": "user", "content": message["text"]})
     return conversation
 
+def clean_messages(messages):
+    clean = []
+    for message in messages:
+        for command in config["bot"]["restricted_commands"]:
+            message["text"] = message["text"].replace(f'!{command}',"")
+        clean.append(message)
+    return clean
+
 # matchers
 
 def gpt_emoji(event) -> bool:
@@ -90,7 +98,7 @@ def tagged(body, event, say):
         channel=event.get("channel"),
         ts=stalling_id, 
         as_user=True, 
-        text=gpt_response
+        text=gpt_response 
     )
     
 @app.event(event="app_mention")
@@ -107,8 +115,9 @@ def emoji_prompt(event, say, body):
         channel=event["item"].get("channel"),
         inclusive=True,
         ts=message_ts)
+    
     logging.info(f'Got authed :chat-gpt: in {event["item"]["channel"]}')
-    struct = structure_reply(bot_id=id,messages=result.data["messages"],ignore_mention=True)
+    struct = structure_reply(bot_id=id,messages=clean_messages(result.data["messages"]),ignore_mention=True)
     struct[-1]["content"] += " !calendar !slack"
     gpt_response = gpt.respond(prompts=struct)
     caveat = "\n(This response was automatically generated)"


### PR DESCRIPTION
Since react responses are the only time the bot will talk outside of an unrestricted channel this effectively ensures that operators cannot accidentally use these restricted commands in a public setting.